### PR TITLE
Add subtitles support

### DIFF
--- a/ConnectSDKSampler/Content/MediaViewController.m
+++ b/ConnectSDKSampler/Content/MediaViewController.m
@@ -348,6 +348,19 @@
     mediaInfo.description = description;
     ImageInfo *imageInfo = [[ImageInfo alloc] initWithURL:iconURL type:ImageTypeThumb];
     [mediaInfo addImage:imageInfo];
+
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if ([defaults boolForKey:@"subtitlesEnabled"] &&
+        [self.device hasCapability:kMediaPlayerSubtitleSRT]) {
+        NSURL *subtitlesURL = [NSURL URLWithString:[defaults stringForKey:@"subtitlesURL"]];
+        SubtitleTrack *subtitleTrack = [SubtitleTrack trackWithURL:subtitlesURL
+                                                          andBlock:^(SubtitleTrackBuilder *builder) {
+                                                              builder.mimeType = [defaults stringForKey:@"subtitlesMimeType"];
+                                                              builder.language = [defaults stringForKey:@"subtitlesLanguage"];
+                                                              builder.label = [defaults stringForKey:@"subtitlesLabel"];
+                                                          }];
+        mediaInfo.subtitleTrack = subtitleTrack;
+    }
     
     [self.device.mediaPlayer playMediaWithMediaInfo:mediaInfo shouldLoop:shouldLoop
                                success:^(MediaLaunchObject *launchObject) {

--- a/ConnectSDKSampler/Content/MediaViewController.m
+++ b/ConnectSDKSampler/Content/MediaViewController.m
@@ -351,7 +351,8 @@
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     if ([defaults boolForKey:@"subtitlesEnabled"] &&
-        [self.device hasCapability:kMediaPlayerSubtitleSRT]) {
+        [self.device hasAnyCapability:@[kMediaPlayerSubtitleSRT,
+                                        kMediaPlayerSubtitleVTT]]) {
         NSURL *subtitlesURL = [NSURL URLWithString:[defaults stringForKey:@"subtitlesURL"]];
         SubtitleTrack *subtitleTrack = [SubtitleTrack trackWithURL:subtitlesURL
                                                           andBlock:^(SubtitleTrackBuilder *builder) {

--- a/ConnectSDKSampler/Settings.bundle/Root.plist
+++ b/ConnectSDKSampler/Settings.bundle/Root.plist
@@ -318,6 +318,58 @@
 		</dict>
 		<dict>
 			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Subtitles Enabled</string>
+			<key>Key</key>
+			<string>subtitlesEnabled</string>
+			<key>DefaultValue</key>
+			<true/>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>Title</key>
+			<string>Subtitles URL</string>
+			<key>Key</key>
+			<string>subtitlesURL</string>
+			<key>DefaultValue</key>
+			<string>http://ec2-54-201-108-205.us-west-2.compute.amazonaws.com/samples/media/sintel_en.srt</string>
+			<key>KeyboardType</key>
+			<string>URL</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>Title</key>
+			<string>Subtitles MIME-Type</string>
+			<key>Key</key>
+			<string>subtitlesMimeType</string>
+			<key>DefaultValue</key>
+			<string>text/srt</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>Title</key>
+			<string>Subtitles Language</string>
+			<key>Key</key>
+			<string>subtitlesLanguage</string>
+			<key>DefaultValue</key>
+			<string>en</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>Title</key>
+			<string>Subtitles Label</string>
+			<key>Key</key>
+			<string>subtitlesLabel</string>
+			<key>DefaultValue</key>
+			<string>English Subtitles</string>
+		</dict>
+		<dict>
+			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>Title</key>
 			<string>Sample Playlist File</string>


### PR DESCRIPTION
- Adds subtitle URL, mime type, language, and label fields and enables switch to app's settings.
- Uses that data for playing video if subtitles are enabled.
